### PR TITLE
Bring in initial Pixel Navbar animation resources

### DIFF
--- a/res/drawable/ic_sysbar_opa_blue.xml
+++ b/res/drawable/ic_sysbar_opa_blue.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape android:shape="oval"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="@dimen/opa_dot_diam" android:width="@dimen/opa_dot_diam" />
+    <solid android:color="#ff4285f4" />
+</shape>


### PR DESCRIPTION
****

This commit just brings in the history and resources from the
fantastic work Jacob did pwning this Google animation here...

USA-RedDragon/frameworks_base-1@5556304

****

Pixel Navbar, reverse engineered from smali.

Notes:
- This is forcing the Pixel Home button on people,
  and it looks ugly with the other nav buttons being hollow

- There MAY still be a few fixes yet to be found in this code
  because it WAS a big file to RE from smali. I have yet to find
  any, but time is the best tester.

- Shoutout to @bigrushdog for providing a decompiled form used
  to verify the smali and as a guideline for the more obsure
  smali sections. It was a big help.

- Tagging myself here to see adoption rate. @USA-RedDragon

Change-Id: Ief1ee04b540c553848698362298719e489fb3585

   